### PR TITLE
Just use "App" for AppName (fix #8)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -13,15 +13,5 @@
     "undef": true,
     "strict": false,
     "trailing": false,
-    "smarttabs": true,
-    "globals": {
-        "App": true,
-        "jQuery": true,
-        "$": true,
-        "Ember": true,
-        "Em": true,
-        "Handlebars": true,
-        "DS": true,
-        "I18n": true
-    }
+    "smarttabs": true
 }

--- a/app/templates/scripts/app.js
+++ b/app/templates/scripts/app.js
@@ -1,4 +1,4 @@
-var <%= _.classify(appname) %> = window.<%= _.classify(appname) %> = Ember.Application.create();
+var App = window.App = Ember.Application.create();
 
 // Order and include as you please.
 require('scripts/l10n/*');

--- a/app/templates/scripts/router.js
+++ b/app/templates/scripts/router.js
@@ -1,3 +1,3 @@
-<%= _.classify(appname) %>.Router.map(function () {
+App.Router.map(function () {
     // Add your routes here
 });

--- a/app/templates/scripts/routes/application_route.js
+++ b/app/templates/scripts/routes/application_route.js
@@ -1,2 +1,2 @@
-<%= _.classify(appname) %>.ApplicationRoute = Ember.Route.extend({
+App.ApplicationRoute = Ember.Route.extend({
 });

--- a/app/templates/scripts/store.js
+++ b/app/templates/scripts/store.js
@@ -1,7 +1,7 @@
-<%= _.classify(appname) %>.ApplicationAdapter = DS.FixtureAdapter;
+App.ApplicationAdapter = DS.FixtureAdapter;
 
 // Add ability to query fixtures in development mode.
-if (<%= _.classify(appname) %>.ApplicationAdapter === DS.FixtureAdapter) {
+if (App.ApplicationAdapter === DS.FixtureAdapter) {
     DS.FixtureAdapter.reopen({
         queryFixtures: function(records, query, type) {
             return records.filter(function(record) {

--- a/app/templates/test/_initializer.js
+++ b/app/templates/test/_initializer.js
@@ -9,11 +9,11 @@ var should = chai.should();
 
 chai.Assertion.includeStack = true;
 
-<%= _.classify(appname) %>.rootElement = "#ember-testing";
+App.rootElement = "#ember-testing";
 Ember.Test.adapter = Ember.Test.MochaAdapter.create();
 
-<%= _.classify(appname) %>.setupForTesting();
-<%= _.classify(appname) %>.injectTestHelpers();
+App.setupForTesting();
+App.injectTestHelpers();
 
 window.start = function () {};
 window.stop = function () {};

--- a/app/templates/test/integration/_index.js
+++ b/app/templates/test/integration/_index.js
@@ -8,7 +8,7 @@ describe("Index page", function () {
 
 describe("ApplicationRoute", function () {
     describe("model property", function () {
-        var applicationRoute = <%= _.classify(appname) %>.ApplicationRoute.create();
+        var applicationRoute = App.ApplicationRoute.create();
         it("should have the right number of items", function () {
             var model = applicationRoute.model();
             model.should.have.length(3);

--- a/controller/templates/base.js
+++ b/controller/templates/base.js
@@ -1,3 +1,3 @@
-<%= _.classify(appname) %>.<%= _.classify(name) %>Controller = Ember.ObjectController.extend({
+App.<%= _.classify(name) %>Controller = Ember.ObjectController.extend({
     // Implement your controller here.
 });

--- a/controller/templates/base_edit.js
+++ b/controller/templates/base_edit.js
@@ -1,4 +1,4 @@
-<%= _.classify(appname) %>.<%= _.classify(name) %>EditController = Ember.ObjectController.extend({
+App.<%= _.classify(name) %>EditController = Ember.ObjectController.extend({
     needs: '<%= name.toLowerCase() %>',
     actions: {
         save: function() {

--- a/controller/templates/plural.js
+++ b/controller/templates/plural.js
@@ -1,3 +1,3 @@
-<%= _.classify(appname) %>.<%= _.classify(pluralized_name) %>Controller = Ember.ObjectController.extend({
+App.<%= _.classify(pluralized_name) %>Controller = Ember.ObjectController.extend({
     // Implement your controller here.
 });

--- a/controller/templates/plural_route.js
+++ b/controller/templates/plural_route.js
@@ -1,4 +1,4 @@
-<%= _.classify(appname) %>.<%= _.classify(pluralized_name) %>Route = Ember.Route.extend({
+App.<%= _.classify(pluralized_name) %>Route = Ember.Route.extend({
     model: function() {
         return this.get('store').find('<%= _.slugify(name) %>');
     }

--- a/controller/templates/single_edit_route.js
+++ b/controller/templates/single_edit_route.js
@@ -1,4 +1,4 @@
-<%= _.classify(appname) %>.<%= _.classify(name) %>EditRoute = Ember.Route.extend({
+App.<%= _.classify(name) %>EditRoute = Ember.Route.extend({
     model: function(params) {
         return this.get('store').find('<%= _.slugify(name) %>',
                                       this.modelFor('<%= _.slugify(name)%>').id);

--- a/controller/templates/single_route.js
+++ b/controller/templates/single_route.js
@@ -1,4 +1,4 @@
-<%= _.classify(appname) %>.<%= _.classify(name) %>Route = Ember.Route.extend({<% if (!singlePage) { %>
+App.<%= _.classify(name) %>Route = Ember.Route.extend({<% if (!singlePage) { %>
     model: function(params) {
         return this.get('store').find('<%= _.slugify(name) %>',
                                       params.<%= _.slugify(name) %>_id);

--- a/model/templates/base.js
+++ b/model/templates/base.js
@@ -1,9 +1,9 @@
-<%= _.classify(appname) %>.<%= _.classify(name) %> = DS.Model.extend({<% _.each(attrs, function(attr, i) { %>
+App.<%= _.classify(name) %> = DS.Model.extend({<% _.each(attrs, function(attr, i) { %>
     <%= _.camelize(attr.name) %>: DS.attr('<%= attr.type %>')<% if(i < (attributes.length - 1)) { %>,<% } %>
 <% }); %>});
 
 // delete below here if you do not want fixtures
-<%= _.classify(appname) %>.<%= _.classify(name) %>.FIXTURES = [
+App.<%= _.classify(name) %>.FIXTURES = [
     <% var ids = [1,2]; _.each(ids, function(idx, id) { %>
     {
         id: <%= id %>,

--- a/router/templates/base.js
+++ b/router/templates/base.js
@@ -1,4 +1,4 @@
-<%= _.classify(appname) %>.Router.map(function () {
+App.Router.map(function () {
 <% _.each(models, function(model, i) { %>
     this.resource('<%= model.plural %>', function() {
         this.resource('<%= model.single %>', {path: '/:<%= model.single %>_id' }, function() {

--- a/test/test.file-creation.js
+++ b/test/test.file-creation.js
@@ -35,6 +35,7 @@ describe('File Creation', function () {
         '../../router',
         '../../app', [
           helpers.createDummyGenerator(),
+          /*jshint scripturl:true*/
           'mocha:app'
         ]
       ]);
@@ -75,9 +76,10 @@ describe('File Creation', function () {
       this.ember.appname = 'some-app';
     });
 
-    it('creates an application object named after the directory usually', function (done) {
+    it('creates an application object named App (see issue #8)',
+       function (done) {
       this.ember.run({}, function () {
-        helpers.assertFileContent('app/scripts/app.js', /var SomeApp = window.SomeApp = Ember\.Application\.create\(\);/);
+        helpers.assertFileContent('app/scripts/app.js', /var App = window.App = Ember\.Application\.create\(\);/);
         done();
       });
     });

--- a/test/test.karma.js
+++ b/test/test.karma.js
@@ -34,6 +34,7 @@ describe('Karma', function () {
         '../../router',
         '../../app', [
           helpers.createDummyGenerator(),
+          /*jshint scripturl:true*/
           'mocha:app'
         ]
       ]);
@@ -46,7 +47,7 @@ describe('Karma', function () {
   });
 
   it('creates files with correct syntax', function (done) {
-    this.ember.app.options['karma'] = true;
+    this.ember.app.options.karma = true;
     EXPECTED_FILES = [
       'karma.conf.js',
       'test/integration/index.js',
@@ -56,10 +57,10 @@ describe('Karma', function () {
       helpers.assertFiles(EXPECTED_FILES);
 
       var content = fs.readFileSync(EXPECTED_FILES[1]);
-      assert(content.toString().match(/Temp.ApplicationRoute/));
+      assert(content.toString().match(/App.ApplicationRoute/));
 
-      var content = fs.readFileSync(EXPECTED_FILES[2]);
-      assert(content.toString().match(/Temp.rootElement/));
+      content = fs.readFileSync(EXPECTED_FILES[2]);
+      assert(content.toString().match(/App.rootElement/));
 
       done();
     });

--- a/view/templates/plural.js
+++ b/view/templates/plural.js
@@ -1,2 +1,2 @@
-<%= _.classify(appname) %>.<%= _.classify(pluralized_name) %>View = Ember.View.extend({
+App.<%= _.classify(pluralized_name) %>View = Ember.View.extend({
 });

--- a/view/templates/single.js
+++ b/view/templates/single.js
@@ -1,2 +1,2 @@
-<%= _.classify(appname) %>.<%= _.classify(name) %>View = Ember.View.extend({
+App.<%= _.classify(name) %>View = Ember.View.extend({
 });

--- a/view/templates/single_edit.js
+++ b/view/templates/single_edit.js
@@ -1,2 +1,2 @@
-<%= _.classify(appname) %>.<%= _.classify(name) %>EditView = Ember.View.extend({
+App.<%= _.classify(name) %>EditView = Ember.View.extend({
 });


### PR DESCRIPTION
There's no sense in doing this fancy `<%= _.classify(appname) %>` thing when most Ember apps just use `App`, and it's easier to follow anyhow!
