### PR TITLE
Add a tab bar to the footer of default template

### DIFF
--- a/app/templates/hbs/application.hbs
+++ b/app/templates/hbs/application.hbs
@@ -10,6 +10,10 @@
     {{outlet}}
   </section>
   <footer>
-    &copy;
+    <x-tabbar>
+      <x-tabbar-tab>
+        {{#link-to 'index'}}{{t app.title}}{{/link-to}}
+      </x-tabbar-tab>
+    </x-tabbar>
   </footer>
 </x-layout>


### PR DESCRIPTION
Largely unstyled, but gives the app a bit more of an "app feel" on startup.
