### PR TITLE
Update Uglify plugin to support npm 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "grunt": "^0.4.2",
     "grunt-casper": "^0.3.3",
     "grunt-contrib-concat": "^0.3.0",
-    "grunt-contrib-uglify": "^0.4.0",
+    "grunt-contrib-uglify": "^0.4.1",
     "grunt-contrib-watch": "^0.5.0",
     "grunt-contrib-jshint": "^0.9.2",
     "grunt-shell": "^0.6.4",


### PR DESCRIPTION
A bug in npm with `peerDependencies`, workaround fix in uglify 0.4.1 

https://github.com/gruntjs/grunt-contrib-uglify/blob/0.4.1/CHANGELOG#L4

Updates PR: https://github.com/mozilla/generator-recroom/pull/18
