### PR TITLE
Don't version icon filenames

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -67,6 +67,7 @@ RecroomGenerator.prototype.createDirLayout = function createDirLayout() {
     this.mkdir('app/templates');
     this.mkdir('app/styles');
     this.mkdir('app/images');
+    this.mkdir('app/images/icons');
     this.mkdir('app/scripts');
     this.mkdir('app/scripts/l10n');
     this.mkdir('app/scripts/models');

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -164,6 +164,7 @@ module.exports = function (grunt) {
                         '<%%= yeoman.dist %>/scripts/{,*/}*.js',
                         '<%%= yeoman.dist %>/styles/{,*/}*.css',
                         '<%%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp}',
+                        '!<%= yeoman.dist %>/images/icons/*',
                         '<%%= yeoman.dist %>/styles/fonts/*'
                     ]
                 }

--- a/app/templates/_manifest.webapp
+++ b/app/templates/_manifest.webapp
@@ -3,13 +3,13 @@
   "name": "<%= appname %>",
   "description": "",
   "icons": {
-    "32": "/images/icon-32.png",
-    "60": "/images/icon-60.png",
-    "64": "/images/icon-64.png",
-    "90": "/images/icon-90.png",
-    "120": "/images/icon-120.png",
-    "128": "/images/icon-128.png",
-    "256": "/images/icon-256.png"
+    "32": "/images/icons/icon-32.png",
+    "60": "/images/icons/icon-60.png",
+    "64": "/images/icons/icon-64.png",
+    "90": "/images/icons/icon-90.png",
+    "120": "/images/icons/icon-120.png",
+    "128": "/images/icons/icon-128.png",
+    "256": "/images/icons/icon-256.png"
   },
   "developer": {
     "name": "<%= process.env.USER %>",


### PR DESCRIPTION
This should resolve mozilla/recroom#25 by creating an `icons` directory under images specifically for application icons. We will ignore this directory in the grunt-rev task so icon filenames do not change.
