### PR TITLE
Limit concurrent htmlmin to dist (fixes #14)

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -292,7 +292,7 @@ module.exports = function (grunt) {
                 'emberTemplates',
                 'imagemin',
                 'svgmin',
-                'htmlmin'
+                'htmlmin:dist'
             ]
         },<%if (options.karma) { %>
         karma: {


### PR DESCRIPTION
It looks like we want to limit to `htmlmin:dist` in the `concurrent:dist` task.

As it is now, in the build step, `htmlmin:deploy` is run when we call `concurrent:dist`.  If `htmlmin:deploy` is run before `usemin`, it won't replace all the scripts in index.html with the combined, minified versions. And we get 404s :(  
