### PR TITLE
Run `grunt test` on port 9001

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -81,7 +81,8 @@ module.exports = function (grunt) {
                             mountFolder(connect, 'test'),
                             mountFolder(connect, '.tmp')
                         ];
-                    }
+                    },
+                    port: 9001
                 }
             },
             dist: {
@@ -128,7 +129,7 @@ module.exports = function (grunt) {
             all: {
                 options: {
                     run: true,
-                    urls: ['http://localhost:<%%= connect.options.port %>/index.html']
+                    urls: ['http://localhost:<%%= connect.test.options.port %>/index.html']
                 }
             }
         },<% } else if (testFramework === 'jasmine') { %>


### PR DESCRIPTION
This will prevent any conflicts if the user's app is already running on port 9000.
